### PR TITLE
p2a was uninitialized. Define p2a as exner(k)

### DIFF
--- a/phys/module_bl_mynn.F
+++ b/phys/module_bl_mynn.F
@@ -2151,6 +2151,7 @@ CONTAINS
     zagl = 0.
 ! Note: kte needs to be larger than kts, i.e., kte >= kts+1.
     DO k = kts,kte-1
+       p2a = exner(k)
        t  = th(k)*exner(k)
 
 !x      if ( ct .gt. 0.0 ) then


### PR DESCRIPTION
I'm not the author of phys/module_bl_mynn.F, but p2a must be initialized.  

Otherwise you can get this error: 
forrtl: error (182): floating invalid - possible uninitialized real/complex variable.


An old version of phys/module_bl_mynn.F initialized  p2a as exner(k). 